### PR TITLE
Group Pereira stimuli by passages

### DIFF
--- a/neural_nlp/benchmarks/neural.py
+++ b/neural_nlp/benchmarks/neural.py
@@ -346,7 +346,8 @@ class _PereiraBenchmark(Benchmark):
 
     def __call__(self, candidate):
         stimulus_set = self._target_assembly.attrs['stimulus_set']
-        model_activations = listen_to(candidate, stimulus_set)
+        stimulus_set.loc[:, 'passage_id'] = stimulus_set['experiment'] + stimulus_set['passage_index'].astype(str)
+        model_activations = listen_to(candidate, stimulus_set, reset_column='passage_id')
         assert set(model_activations['stimulus_id'].values) == set(self._target_assembly['stimulus_id'].values)
 
         _logger.info('Scoring across experiments & atlases')


### PR DESCRIPTION
Group stimuli by passage (instead of "story") for the Pereira benchmark when computing model activations